### PR TITLE
board design fix

### DIFF
--- a/src/main/resources/static/css/list1.css
+++ b/src/main/resources/static/css/list1.css
@@ -5,16 +5,23 @@ body {
     background-color: #f2f2f2;
     color: #333;
     line-height: 1.6;
+    margin: 0;  /* 기본 여백 제거 */
+    padding: 0; /* 기본 패딩 제거 */
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh; /* 화면 전체 높이 설정 */
 }
 
 /* 컨테이너 스타일 */
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
+    width: 1200px;
+    margin: 40px auto;
     padding: 20px;
     background-color: #fff;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    flex: 1; /* 남은 공간을 차지하도록 설정 */
 }
+
 
 /* 페이지 헤더 스타일 */
 .page-header {

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -26,7 +26,7 @@
     <!-- 헤더 포함 -->
     <div th:insert="~{header_common :: header}"></div>
 
-    <div class="container" layout:fragment="content">
+    <div class="container" layout:fragment="content" style="padding-top: 20px; padding-bottom: 20px;">
 
         <div class="page-header">
             <h1>PETDOC</h1>
@@ -59,28 +59,26 @@
                             <td th:text="${#temporals.format(board.updatedDate, 'yyyy-MM-dd HH:mm')}"></td>
                             <td th:text="${board.writer}"></td>
                         </tr>
-                        <tr>
-                            <td colspan="5">
-                                <div th:if="${board.comments.size() > 0}" class="comment-section">
-                                    <h5>댓글:</h5>
-                                    <ul>
-                                        <li th:each="comment : ${board.comments}">
-                                            <p><strong th:text="${comment.writer}"></strong>: <span th:text="${comment.content}"></span></p>
-                                        </li>
-                                    </ul>
-                                </div>
-                                <div th:if="${board.comments.size() == 0}" class="no-comment">
-                                    <p>댓글이 없습니다.</p>
-                                </div>
-                            </td>
-                        </tr>
+                        <th:block th:if="${board.comments.size() > 0}">
+                            <tr>
+                                <td colspan="5">
+                                    <div class="comment-section">
+                                        <h5>댓글:</h5>
+                                        <ul>
+                                            <li th:each="comment : ${board.comments}">
+                                                <p><strong th:text="${comment.writer}"></strong>: <span th:text="${comment.content}"></span></p>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </td>
+                            </tr>
+                        </th:block>
                     </th:block>
                 </tbody>
             </table>
         </div>
     </div>
 </div>
-
 
     <!-- 이 위치에 Bootstrap/Jquery core JavaScript가 구성된다. -->
 
@@ -136,7 +134,7 @@
         }
         </script>
     </th:block>
-
+</div>
     <!-- 푸터 포함 -->
     <div th:insert="~{footer.html}"></div>
 </body>


### PR DESCRIPTION
작성 일자 : 2024-07-03 (수) 00:25 a.m
작성자 : Greedy92
작성내용 : 

1. 컨테이너 내용이 많을 경우, 헤더와 푸터를 일부 가리던 현상을 수정했습니다.
2. 댓글이 없을 경우에도, 공백으로 행이 추가되는 현상을 수정했습니다.
3. 컨테이너의 내용이 너무 작아, 푸터 아래까지 뷰가 보여지던 현상을 수정했습니다.
